### PR TITLE
Add new task creation modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <h1>タスク管理ボード</h1>
+    <button id="addTaskBtn">タスクを追加</button>
     <div id="board">
         <div class="column" id="todo" ondrop="drop(event)" ondragover="allowDrop(event)">
             <h2>未着手</h2>
@@ -20,6 +21,22 @@
         </div>
         <div class="column" id="onhold" ondrop="drop(event)" ondragover="allowDrop(event)">
             <h2>保留</h2>
+        </div>
+    </div>
+    <div id="taskModal" class="modal">
+        <div class="modal-content">
+            <label for="taskContent">タスク内容</label>
+            <input type="text" id="taskContent">
+            <label for="taskType">タスクの種類</label>
+            <input type="text" id="taskType">
+            <label for="taskAssignee">担当者名</label>
+            <input type="text" id="taskAssignee">
+            <label for="taskColor">付箋の色</label>
+            <input type="color" id="taskColor" value="#fffb8f">
+            <div class="buttons">
+                <button id="createTask">作成</button>
+                <button id="closeModal">閉じる</button>
+            </div>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -14,3 +14,49 @@ function drop(ev) {
         ev.currentTarget.appendChild(note);
     }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('taskModal');
+    const addBtn = document.getElementById('addTaskBtn');
+    const closeBtn = document.getElementById('closeModal');
+    const createBtn = document.getElementById('createTask');
+
+    addBtn.addEventListener('click', () => {
+        modal.style.display = 'block';
+    });
+
+    closeBtn.addEventListener('click', () => {
+        modal.style.display = 'none';
+    });
+
+    createBtn.addEventListener('click', () => {
+        const content = document.getElementById('taskContent').value;
+        const type = document.getElementById('taskType').value;
+        const assignee = document.getElementById('taskAssignee').value;
+        const color = document.getElementById('taskColor').value;
+
+        if (!content) return;
+
+        const note = document.createElement('div');
+        note.className = 'note';
+        note.draggable = true;
+        note.id = 'task' + Date.now();
+        note.style.backgroundColor = color;
+        note.ondragstart = drag;
+        note.innerHTML = `<div>${content}</div><div>${type}</div><div>${assignee}</div>`;
+
+        document.getElementById('todo').appendChild(note);
+
+        modal.style.display = 'none';
+        document.getElementById('taskContent').value = '';
+        document.getElementById('taskType').value = '';
+        document.getElementById('taskAssignee').value = '';
+        document.getElementById('taskColor').value = '#fffb8f';
+    });
+
+    window.addEventListener('click', (e) => {
+        if (e.target === modal) {
+            modal.style.display = 'none';
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -36,3 +36,34 @@ body {
     margin: 10px 0;
     cursor: move;
 }
+
+#addTaskBtn {
+    margin: 10px 20px;
+    padding: 8px 12px;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+    background-color: #fff;
+    margin: 10% auto;
+    padding: 20px;
+    width: 300px;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.modal-content .buttons {
+    display: flex;
+    justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- add a button to create tasks
- implement a modal to fill out task information
- dynamically create new sticky notes in the 未着手 column

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850c84a4cfc8326b33f3de5ba2f9d1b